### PR TITLE
Ignore auto-generated files from build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Temporary files
+*~
+*.swp
+
+# Files
+*.vcxproj
+*.vcxproj.user
+*.vcxproj.filters
+*.sln
+*.log
+Makefile


### PR DESCRIPTION
This is the first in a series of PRs to clean up the build of Walnut-Chat Headless on Linux.

This PR just ensures that some auto-generated files from premake5 are ignored by Git.
